### PR TITLE
Fix for Discourse 2.8 compatibility

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -5,6 +5,7 @@
 
 enabled_site_setting :cookie_ui_enabled
 
-load File.expand_path("../current_user_provider.rb", __FILE__)
-
-Discourse.current_user_provider = ExCurrentUserProvider
+after_initialize do
+  load File.expand_path("../current_user_provider.rb", __FILE__)
+  Discourse.current_user_provider = ExCurrentUserProvider
+end


### PR DESCRIPTION
The class definition should now be within the `after_initialize` block, otherwise it will yield an `uninitialized constant Auth::DefaultCurrentUserProvider` error.
